### PR TITLE
Add checks for mod_expires

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,6 +5,8 @@
   php_value include_path ".:/var/www/common"
 </IfModule>
 
-AddType image/vnd.microsoft.icon .ico
-ExpiresActive on
-ExpiresByType image/vnd.microsoft.icon "access plus 3 months"
+<IfModule mod_expires.c>
+  AddType image/vnd.microsoft.icon .ico
+  ExpiresActive on
+  ExpiresByType image/vnd.microsoft.icon "access plus 3 months"
+</IfModule>

--- a/css/.htaccess
+++ b/css/.htaccess
@@ -1,3 +1,4 @@
-ExpiresActive On
-ExpiresByType text/css "access plus 1 month"
-
+<IfModule mod_expires.c>
+  ExpiresActive On
+  ExpiresByType text/css "access plus 1 month"
+</IfModule>

--- a/js/.htaccess
+++ b/js/.htaccess
@@ -1,12 +1,14 @@
-<FilesMatch "^jquery">
+<IfModule mod_expires.c>
+  <FilesMatch "^jquery">
     ExpiresActive On
     ExpiresDefault "access plus 1 month"
-</FilesMatch>
-<FilesMatch "^bootstrap">
+  </FilesMatch>
+  <FilesMatch "^bootstrap">
     ExpiresActive On
     ExpiresDefault "access plus 1 month"
-</FilesMatch>
-<FilesMatch "\.min.js">
+  </FilesMatch>
+  <FilesMatch "\.min.js">
     ExpiresActive On
     ExpiresDefault "access plus 1 week"
-</FilesMatch>
+  </FilesMatch>
+</IfModule>


### PR DESCRIPTION
Ubuntu doesn't have this apache mod enabled by default. This fixes errors caused by the htaccess files if this module isn't enabled. 